### PR TITLE
Setting the right type to the filters.

### DIFF
--- a/modules/ximgproc/src/niblack_thresholding.cpp
+++ b/modules/ximgproc/src/niblack_thresholding.cpp
@@ -70,9 +70,9 @@ void niBlackThreshold( InputArray _src, OutputArray _dst, double maxValue,
     if( src.data != dst.data )
         mean = dst;
 
-    boxFilter( src, mean, CV_64F, Size(blockSize, blockSize),
+    boxFilter( src, mean, CV_32F, Size(blockSize, blockSize),
             Point(-1,-1), true, BORDER_REPLICATE );
-    sqrBoxFilter( src, sqmean, CV_64F, Size(blockSize, blockSize),
+    sqrBoxFilter( src, sqmean, CV_32F, Size(blockSize, blockSize),
             Point(-1,-1), true, BORDER_REPLICATE );
 
     // Compute (k * standard deviation) in the neighborhood of each pixel


### PR DESCRIPTION
Since the mean and sqmean are float the type of the filter must also be float.